### PR TITLE
Dynamic resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## DRAFT
+## Unreleased
+
+The only breaking change in this release is that `resource.body("")` now can reference path and query parameters. What it means is that if `{path.<param_name>}` or `{query.<param_name>}` is provided, they will be translated to the values received in the request.
+
+### Added
+
+- Support to query and path parameters.
+- Support to using query and path parameters in body response.
+- Support to dynamic body.
+
+### Changed
+
+- Renamed some internal variables and methods in Resource.
+- Changed how server matches resources.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ description = "Programatically create resources and pre-defined responses for te
 keywords = ["http", "test", "server", "stream"]
 
 [dependencies]
+regex = "1"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 Programatically create end-points that listen for connections and return pre-defined responses.
 
 - Allows multiple endpoints and simultaneous client connections
-- Resource builder for creating endpoints
 - Streaming support
 - Helper functions to retrieve data such as request count, number of connected clients and
 requests metadata
@@ -49,6 +48,31 @@ resource
 // Cache-Control: no-cache\r\n
 // \r\n
 // { "message": "this is a message" }
+```
+
+Use path parameters
+```rust
+extern crate http_test_server;
+
+use http_test_server::{TestServer, Resource};
+use http_test_server::http::{Status, Method};
+
+let server = TestServer::new().unwrap();
+let resource = server.create_resource("/user/{userId}");
+
+resource
+    .status(Status::OK)
+    .header("Content-Type", "application/json")
+    .header("Cache-Control", "no-cache")
+    .body(r#"{ "id": "{path.userId}" }"#);
+
+// request: GET /user/abc123
+
+// HTTP/1.1 200 Ok\r\n
+// Content-Type: application/json\r\n
+// Cache-Control: no-cache\r\n
+// \r\n
+// { "id": "abc123" }
 ```
 
 Expose a persistent stream:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ resource
 // { "message": "this is a message" }
 ```
 
-Use path parameters
+Use path and query parameters
 ```rust
 extern crate http_test_server;
 
@@ -58,13 +58,13 @@ use http_test_server::{TestServer, Resource};
 use http_test_server::http::{Status, Method};
 
 let server = TestServer::new().unwrap();
-let resource = server.create_resource("/user/{userId}");
+let resource = server.create_resource("/user/{userId}?filter=*");
 
 resource
     .status(Status::OK)
     .header("Content-Type", "application/json")
     .header("Cache-Control", "no-cache")
-    .body(r#"{ "id": "{path.userId}" }"#);
+    .body(r#"{ "id": "{path.userId}", "filter": "{query.filter}" }"#);
 
 // request: GET /user/abc123
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ resource
     .header("Cache-Control", "no-cache")
     .body(r#"{ "id": "{path.userId}", "filter": "{query.filter}" }"#);
 
-// request: GET /user/abc123
+// request: GET /user/abc123?filter=all
 
 // HTTP/1.1 200 Ok\r\n
 // Content-Type: application/json\r\n
 // Cache-Control: no-cache\r\n
 // \r\n
-// { "id": "abc123" }
+// { "id": "abc123", "filter": "all" }
 ```
 
 Expose a persistent stream:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ impl TestServer {
     /// [`Resource`]: struct.Resource.html
     pub fn create_resource(&self, uri: &str) -> Resource {
         let mut resources = self.resources.lock().unwrap();
-        let resource = Resource::new();
+        let resource = Resource::new(uri);
 
         if resources.contains_key(uri) {
             let resources_for_uri =  resources.get_mut(uri).unwrap();
@@ -338,9 +338,9 @@ fn find_resource(method: String, url: String, resources: ServerResources) -> Res
                     resource.increment_request_count();
                     resource.clone()
                 },
-                None => Resource::new().status(Status::MethodNotAllowed).clone()
+                None => Resource::new(&url).status(Status::MethodNotAllowed).clone()
             },
-        None => Resource::new().status(Status::NotFound).clone()
+        None => Resource::new(&url).status(Status::NotFound).clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,13 @@
 //!     .header("Cache-Control", "no-cache")
 //!     .body(r#"{ "id": "{path.userId}", "filter": "{query.filter}" }"#);
 //!
-//! // request: GET /user/abc123
+//! // request: GET /user/abc123?filter=all
 //!
 //! // HTTP/1.1 200 Ok\r\n
 //! // Content-Type: application/json\r\n
 //! // Cache-Control: no-cache\r\n
 //! // \r\n
-//! // { "id": "abc123" }
+//! // { "id": "abc123", "filter": "all" }
 //!
 //!
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! ```
 //!
-//! Use path parameters:
+//! Use path and query parameters:
 //! ```
 //! extern crate http_test_server;
 //!
@@ -59,13 +59,13 @@
 //! use http_test_server::http::{Status, Method};
 //!
 //! let server = TestServer::new().unwrap();
-//! let resource = server.create_resource("/user/{userId}");
+//! let resource = server.create_resource("/user/{userId}?filter=*");
 
 //! resource
 //!     .status(Status::OK)
 //!     .header("Content-Type", "application/json")
 //!     .header("Cache-Control", "no-cache")
-//!     .body(r#"{ "id": "{path.userId}" }"#);
+//!     .body(r#"{ "id": "{path.userId}", "filter": "{query.filter}" }"#);
 //!
 //! // request: GET /user/abc123
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@
 //!
 //!
 //! ```
+extern crate regex;
+
 pub mod resource;
 pub mod http;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -71,6 +71,21 @@ fn test_stream() {
     assert_eq!(response, "HTTP/1.1 200 Ok\r\nContent-Type: text/event-stream\r\n\r\n: initial data\nHello.\nIs there anybody in there?\nJust nod if you can hear me.\n");
 }
 
+#[test]
+fn test_request_with_path_params() {
+    let server = TestServer::new().unwrap();
+    let resource = server.create_resource("/user/{userId}");
+
+    resource
+        .status(Status::OK)
+        .header("Content-Type", "application/json")
+        .body(r#"{"id": 123, "userId": "{path.userId}"}"#);
+
+    let response = request(server.port(), "/user/superUser", "GET");
+
+    assert_eq!(response, "HTTP/1.1 200 Ok\r\nContent-Type: application/json\r\n\r\n{\"id\": 123, \"userId\": \"superUser\"}");
+}
+
 fn request(port: u16, uri: &str, method: &str) -> String {
     let stream = open_stream(port, uri, method);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -72,18 +72,21 @@ fn test_stream() {
 }
 
 #[test]
-fn test_request_with_path_params() {
+fn test_request_with_path_and_query_params() {
     let server = TestServer::new().unwrap();
-    let resource = server.create_resource("/user/{userId}");
+    let resource = server.create_resource("/user/{userId}?filter=*&version=1");
 
     resource
         .status(Status::OK)
         .header("Content-Type", "application/json")
-        .body(r#"{"id": 123, "userId": "{path.userId}"}"#);
+        .body(r#"{"id": 123, "userId": "{path.userId}", "filter": "{query.filter}", "v": {query.version}}"#);
 
-    let response = request(server.port(), "/user/superUser", "GET");
+    let response = request(server.port(), "/user/superUser?filter=all&version=1", "GET");
 
-    assert_eq!(response, "HTTP/1.1 200 Ok\r\nContent-Type: application/json\r\n\r\n{\"id\": 123, \"userId\": \"superUser\"}");
+    assert_eq!(
+        response,
+        "HTTP/1.1 200 Ok\r\nContent-Type: application/json\r\n\r\n{\"id\": 123, \"userId\": \"superUser\", \"filter\": \"all\", \"v\": 1}"
+    );
 }
 
 fn request(port: u16, uri: &str, method: &str) -> String {


### PR DESCRIPTION
As suggested in https://github.com/viniciusgerevini/http-test-server/issues/1 and https://github.com/viniciusgerevini/http-test-server/issues/2.

Currently, it's only possible to match resources with fixed URIs and to return fixed responses.

The goal in this PR is to :

- allow path params and query params in resource URLs
- provide ways to use those parameters in the response

Here is a sample of the initial API definition:

## Path parameters
Defining path parameters using `{ }`
```rust
let resource = server.create_resource("/user/{id}/collection/{collectionId}");
```
I'll show you how to use their values in the dynamic response section.

## Query parameters

```rust
resource
    .status(Status::Created)
    .method(Method::GET)
    .query("userId", "123") // Resource will only respond to requests with this value
    .query("someValue", "*") // Resource will capture requests with any value in this parameter
    // [...]
    ;
```

As an alternative, query params could be defined like this:
``` rust
let resource = server.create_resource("/endpoint?userId=123&someValue=*");
``` 

## Response

The dynamic response can be defined in two different ways: through a template body or a builder function.

### Template body
```rust
resource
    .body("Hello {query.name}, Your id is: {path.userId}");
// for /endpoint/123?name="Jane"
// the response is "Hello Jane, Your id is: 123
```

Same result using a builder function:
```rust
resource.body_fn(|params| format!("Hello {}, Your id is: {}", params.query.get("name").unwrap(), params.path.get("userId").unwrap()));
```

It may look more verbose, but it allows you to do something like:
```rust
resource.body_fn(|params| {
    if params.path.get("type").unwrap() == "Balrog" {
        return "YOU SHALL NOT PASS!".to_string();
    }

    return "Fly, you fools!".to_string();
});
```
I'm not a big fan of this kind of mocks as they increase test complexity, but I'm not here to judge. Use it with responsibility.

These APIs may change.

_TODO_:
* [x] path parameters matching
* [x] query parameters (method) 
* [x] query parameters (in URI) 
* [x] body template
* [x]  body fn