### PR TITLE
chore: bind server to 127.0.0.1 to avoid extra lookup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,9 +142,9 @@
 //! *NOTE*: This is not intended to work as a full featured server. For this reason, many validations
 //! and behaviours are not implemented. e.g: A request with `Accept` header with not supported
 //! `Content-Type` won't trigger a `406 Not Acceptable`.
-//! 
+//!
 //! As this crate was devised to be used in tests, smart behaviours could be confusing and misleading. Having said that, for the sake of convenience, some default behaviours were implemented:
-//! 
+//!
 //! - Server returns `404 Not Found` when requested resource was not configured.
 //! - Server returns `405 Method Not Allowed` when trying to reach resource with different method from those configured.
 //! - When a resource is created it responds to `GET` with `200 Ok` by default.
@@ -201,7 +201,7 @@ impl TestServer {
     ///
     /// ```
     pub fn new_with_port(port: u16) -> Result<TestServer, Error> {
-        let listener = TcpListener::bind(format!("localhost:{}", port)).unwrap();
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", port)).unwrap();
         let port = listener.local_addr()?.port();
         let resources: ServerResources = Arc::new(Mutex::new(vec!()));
         let requests_tx = Arc::new(Mutex::new(None));
@@ -252,7 +252,7 @@ impl TestServer {
     /// server.close();
     /// ```
     pub fn close(&self) {
-        if let Ok(mut stream) = TcpStream::connect(format!("localhost:{}", self.port)) {
+        if let Ok(mut stream) = TcpStream::connect(format!("127.0.0.1:{}", self.port)) {
             stream.write_all(b"CLOSE").unwrap();
             stream.flush().unwrap();
         }
@@ -416,7 +416,7 @@ mod tests {
     }
 
     fn request(port: u16, uri: &str, method: &str) -> TcpStream {
-        let host = format!("localhost:{}", port);
+        let host = format!("127.0.0.1:{}", port);
         let mut stream = TcpStream::connect(host).unwrap();
         let request = format!(
             "{} {} HTTP/1.1\r\nContent-Type: text\r\n\r\n",
@@ -457,7 +457,7 @@ mod tests {
 
         thread::sleep(Duration::from_millis(200));
 
-        let host = format!("localhost:{}", server.port());
+        let host = format!("127.0.0.1:{}", server.port());
         let stream = TcpStream::connect(host);
 
         assert!(stream.is_err());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -107,6 +107,25 @@ fn test_request_to_regex_uri() {
     assert_eq!(resource.request_count(), 1);
 }
 
+#[test]
+fn request_to_loopback_ip() {
+    let server = TestServer::new().unwrap();
+    let resource = server.create_resource("/hello");
+
+    let host = format!("127.0.0.1:{}", server.port());
+    let mut stream = TcpStream::connect(host).unwrap();
+
+    stream.write("GET /hello HTTP/1.1\r\n\r\n".as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_to_string(&mut response).unwrap();
+
+    assert_eq!(response, "HTTP/1.1 200 Ok\r\n\r\n");
+    assert_eq!(resource.request_count(), 1);
+}
+
 
 fn request(port: u16, uri: &str, method: &str) -> String {
     let stream = open_stream(port, uri, method);


### PR DESCRIPTION
Currently test server is binded to localhost, instead of 127.0.0.1. This is causing some issues on windows as mentioned on https://github.com/viniciusgerevini/http-test-server/issues/7, including:
- localhost requires a lookup on hosts configuration, potentially exposing the server to the external network
- the extra lookup makes localhost less performant than using a loopback IP.
- windows seems to treat binding on localhost differently than linux and MacOS.
