### PR TITLE
Added a new api function create_resource_with_regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ resource_target.body("Hi!");
 // \r\n
 ```
 
-Regex URI:
+Simple Regex URI:
 
 ```rust
 let server = TestServer::new().unwrap();
@@ -124,6 +124,20 @@ let resource = server.create_resource("/hello/[0-9]/[A-z]/.*");
 // \r\n
 
 ```
+Complex regex with custom capture groups:
+
+```rust
+let server = TestServer::new().unwrap();
+let resource = server.create_resource_with_regex("/hello/(?<id>[0-9])/[A-z]/.*");
+resource.body("id: {path.id}");
+
+// request: GET /hello/8/b/doesntmatter-hehe
+// HTTP/1.1 200 Ok\r\n
+// \r\n
+// id: 8
+
+```
+
 
 Check  [/tests/integration_test.rs](tests/integration_test.rs) for more usage examples.
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -63,10 +63,17 @@ pub struct Resource {
     is_stream: Arc<AtomicBool>,
     stream_listeners: Arc<Mutex<Vec<mpsc::Sender<String>>>>
 }
-
-struct URIParameters {
+pub(crate) struct URIParameters {
     path: Vec<String>,
     query: HashMap<String, String>
+}
+impl URIParameters {
+    pub fn new(path: Vec<String>, query: HashMap<String, String>) -> Self {
+        Self {
+            path,
+            query
+        }
+    }
 }
 
 type BodyBuilder = Box<dyn Fn(RequestParameters) -> String + Send>;
@@ -74,7 +81,9 @@ type BodyBuilder = Box<dyn Fn(RequestParameters) -> String + Send>;
 impl Resource {
     pub(crate) fn new(uri: &str) -> Resource {
         let (uri_regex, params) = create_uri_regex(uri);
-
+        Self::new_with_regex(uri, uri_regex, params)
+    }
+    pub(crate) fn new_with_regex(uri: &str, uri_regex: Regex, params: URIParameters) -> Resource {
         Resource {
             uri: String::from(uri),
             uri_regex,


### PR DESCRIPTION
This function will pass the uri as is to the Resource engine. No additional processing is done to check for query parameters and other path captures. The uri will be saved as a valid regex. It will also extract named captures from the regex and pass it to the Request parameters so that users can still use the original api of:

```rust
let server = TestServer::new().unwrap();
let resource = server.create_resource_with_regex("^/(?<group_id>.*)/(?<artifact_id>.*)/maven-metadata.xml$");
resource.status(Status::OK).body("{path.group_id}:{path.artifact_id}");
```
or

```rust
let server = TestServer::new().unwrap();
let resource = server.create_resource_with_regex("^/(?<group_id>.*)/(?<artifact_id>.*)/maven-metadata.xml$");
resource.method(Method::GET).status(Status::OK)
            .body_fn(|param| {
                let group_id = param.path.get("group_id").unwrap();
                let artifact_id = param.path.get("artifact_id").unwrap();

                format!("{group_id}:{artifact_id}")
            });
```

This will allow for fine grained control of uri therefore allowing extraction of uri segments for further processing of body response.

*Did not affect the existing api.*